### PR TITLE
Renamed changelog file for github updater

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,9 @@
+### ChangeLog for Title Capitalization for WordPress
+
+#### 1.0.1 / 2014-04-21
+
+* Renamed changelog file for github updater
+
+#### 1.0.0 / 2014-04-20
+
+* Initial commit

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,0 @@
-### ChangeLog for Title Capitalization for WordPress
-
-#### 1.0.0 / 2014-04-20
-
-* Initial commit


### PR DESCRIPTION
You might want to use that name because the Github updater uses it to display changes.

Cool plugin btw.
