### PR TITLE
fix to work with JetPack Markdown and variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ### ChangeLog for Title Capitalization for WordPress
 
+#### 1.1.3 / 2015-01-02
+
+* Updated to work with Markdown markup for headers and leaves markdown markup intact
+* Fix for [JetPack Markdown](https://github.com/tommcfarlin/title-capitalization-for-wordpress/issues/5)
+
 #### 1.1.2 / 2014-05-04
 
 * Fixing a problem with the core plugin file that was not showing updates from the GitHub Updater

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 * Contributors: [tommcfarlin](http://tommcfarlin.com/)
 * Tags: posts
 * Requires at least: 3.9.0
-* Tested up to: 3.9.0
-* Stable tag: 1.1.2
+* Tested up to: 4.1
+* Stable tag: 1.1.3
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -13,6 +13,8 @@ Properly capitalizes post titles and heading elements in the post content.
 
 Title Capitalization for WordPress provide proper capitalization for your post titles
 and heading elements (that is, `h1`, ..., `h6` in your post content).
+
+Works with Markdown header markup.
 
 The plugin will fire whenever you manually save a draft, publish a post, or update a post.
 

--- a/admin/class-title-capitalizer.php
+++ b/admin/class-title-capitalizer.php
@@ -103,7 +103,7 @@ class Title_Capitalizer {
 
 		// When $data and $arr_post disagree use $arr_post
 		if ( ! empty( $arr_post['post_content_filtered'] ) &&
-		     $arr_post['post_content_filtered'] != $content_filtered ||
+		     $arr_post['post_content_filtered'] != $data['post_content_filtered'] ||
 		     isset( $_POST['content'] ) && ( $_POST['content'] === $arr_post['post_content_filtered'] )
 		) {
 			$content_filtered = $arr_post['post_content_filtered'];

--- a/admin/class-title-capitalizer.php
+++ b/admin/class-title-capitalizer.php
@@ -99,22 +99,29 @@ class Title_Capitalizer {
 
 			$regex = "#(<h$i>)(.*)(</h$i>)#i";
 			preg_match_all( $regex, $content, $matches );
-			$matches = $matches[0];
+			$matches_html = $matches[0];
 
-			if ( empty( $matches ) && ! $md_matches ) {
+			if ( empty( $matches_html ) && ! $md_matches ) {
 				$regex = "/#(.*)(\r|\n)/i";
-				preg_match_all( $regex, $content, $matches );
-				$matches = $matches[0];
+				preg_match_all( $regex, $content_filtered, $matches );
+				$matches_md = $matches[0];
 				$md_matches = true;
 			}
 
-			for ( $j = 0, $l = count( $matches ); $j < $l; $j++ ) {
-				$content = str_ireplace( $matches[ $j ], $this->title_case->toTitleCase( $matches[ $j ] ), $content );
+			for ( $j = 0, $l = count( $matches_html ); $j < $l; $j++ ) {
+				$content          = str_ireplace( $matches_html[ $j ], $this->title_case->toTitleCase( $matches_html[ $j ] ), $content );
+				$content_filtered = str_ireplace( $matches_html[ $j ], $this->title_case->toTitleCase( $matches_html[ $j ] ), $content_filtered );
+			}
+
+			for ( $j = 0, $l = count( $matches_md ); $j < $l; $j++ ) {
+				$content_filtered = str_ireplace( $matches_md[ $j ], $this->title_case->toTitleCase( $matches_md[ $j ] ), $content_filtered );
+
 			}
 
 		}
 
-		$data['post_content'] = $content;
+		$data['post_content_filtered'] = $content_filtered;
+		$data['post_content']          = $content;
 
 		return $data;
 

--- a/admin/class-title-capitalizer.php
+++ b/admin/class-title-capitalizer.php
@@ -84,16 +84,35 @@ class Title_Capitalizer {
 	 *
 	 * @param   array  $data       The sanitized post data
 	 * @param   array  $arr_post   The raw post data
-	 * @return  array  $data       The sanitized post data with properly capitalized elements
+	 * @return  bool|array  $data       The sanitized post data with properly capitalized elements
 	 */
 	public function capitalize_post_content( $data, $arr_post ) {
 
 		if ( isset( $arr_post['post_ID'] ) && ! $this->should_save_post( $arr_post['post_ID'] ) ) {
-			return;
+			return false;
 		}
 
-		$content    = isset( $data['post_content_filtered'] ) ? $data['post_content_filtered'] : $data['post_content'];
-		$md_matches = false;
+		$content          = $data['post_content'];
+		$content_filtered = null;
+		$md_matches       = false;
+
+		// Start by getting from $data
+		if ( ! empty( $data['post_content_filtered'] ) ) {
+			$content_filtered = $data['post_content_filtered'];
+		}
+
+		// When $data and $arr_post disagree use $arr_post
+		if ( ! empty( $arr_post['post_content_filtered'] ) &&
+		     $arr_post['post_content_filtered'] != $content_filtered ||
+		     isset( $_POST['content'] ) && ( $_POST['content'] === $arr_post['post_content_filtered'] )
+		) {
+			$content_filtered = $arr_post['post_content_filtered'];
+		}
+
+		// Use $data when $_POST and $data are same, like when updating
+		if ( isset( $_POST['content'] ) && ( $_POST['content'] === $data['post_content_filtered'] ) ) {
+			$content_filtered = $data['post_content_filtered'];
+		}
 
 		for ( $i = 1; $i <= 6; $i++ ) {
 

--- a/admin/class-title-capitalizer.php
+++ b/admin/class-title-capitalizer.php
@@ -92,12 +92,21 @@ class Title_Capitalizer {
 			return;
 		}
 
-		$content = $data['post_content'];
+		$content    = isset( $data['post_content_filtered'] ) ? $data['post_content_filtered'] : $data['post_content'];
+		$md_matches = false;
+
 		for ( $i = 1; $i <= 6; $i++ ) {
 
 			$regex = "#(<h$i>)(.*)(</h$i>)#i";
 			preg_match_all( $regex, $content, $matches );
 			$matches = $matches[0];
+
+			if ( empty( $matches ) && ! $md_matches ) {
+				$regex = "/#(.*)(\r|\n)/i";
+				preg_match_all( $regex, $content, $matches );
+				$matches = $matches[0];
+				$md_matches = true;
+			}
 
 			for ( $j = 0, $l = count( $matches ); $j < $l; $j++ ) {
 				$content = str_ireplace( $matches[ $j ], $this->title_case->toTitleCase( $matches[ $j ] ), $content );

--- a/title-capitalization-for-wordpress.php
+++ b/title-capitalization-for-wordpress.php
@@ -18,7 +18,7 @@
  * Plugin Name:       Title Capitalization For WordPress
  * Plugin URI:        http://tommcfarlin.com/title-capitalization-for-wordpress/
  * Description:       Converts post and page titles and post content headings into proper capitalization.
- * Version:           1.1.2
+ * Version:           1.1.3
  * Author:            Tom McFarlin
  * Author URI:        http://tommcfarlin.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
also now capitalizes Markdown header markup.

Should fix #5 