### PR TITLE
I really hate regex!!!!!

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,3 @@
-### ChangeLog for Title Capitalization for WordPress
-
 #### 1.1.3 / 2015-01-02
 
 * Updated to work with Markdown markup for headers and leaves markdown markup intact

--- a/admin/class-title-capitalizer.php
+++ b/admin/class-title-capitalizer.php
@@ -115,16 +115,12 @@ class Title_Capitalizer {
 		}
 
 		// Get h1 to h6 headers
-		for ( $i = 1; $i <= 6; $i++ ) {
-			$regex = "#(<h$i>)(.*)(</h$i>)#i";
-			preg_match_all( $regex, $content, $matches );
-			if ( ! empty( $matches[0] ) ) {
-				$header_matches = array_merge( $header_matches, $matches[0] );
-			}
-		}
+		$regex = "#<h([1-6])>(.*)</h\\1>#i";
+		preg_match_all( $regex, $content, $matches );
+		$header_matches = array_merge( $header_matches, $matches[0] );
 
 		// Get Markdown markup headers
-		$regex = "/#(.*)(\r|\n)/i";
+		$regex = "/(?<!\\S)(?:^)#(.*)(\r|\n)/m";
 		preg_match_all( $regex, $content_filtered, $matches );
 		$header_matches = array_merge( $header_matches, $matches[0] );
 


### PR DESCRIPTION
now will grab correctly for multiple instances and only at beginning of line per Markdown syntax and simplified grabbing of h1 to h6 tags

I **think** it should now match only what is a valid header tag either regular or markdown.