### PR TITLE
Fix post-apostrophe cap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+#### 1.1.4 / 2015-07-06
+
+* Fixing a problem in `class TitleCase` so letters following apostrophes aren't capitalized. [Issue #5](https://github.com/tommcfarlin/title-capitalization-for-wordpress/issues/11)
+* Adding header `Network: false` as the plugin doesn't like being Network Activated. This doesn't prevent Network Activation. :P
+
 #### 1.1.3 / 2015-01-02
 
 * Updated to work with Markdown markup for headers and leaves markdown markup intact

--- a/includes/vendor/class-title-case.php
+++ b/includes/vendor/class-title-case.php
@@ -26,7 +26,7 @@ class TitleCase {
 			//(never on the first word, and never if preceded by a colon)
 			$m = $i>0 && mb_substr ($title, max (0, $i-2), 1, 'UTF-8') !== ':' &&
 				!preg_match ('/[\x{2014}\x{2013}] ?/u', mb_substr ($title, max (0, $i-2), 2, 'UTF-8')) &&
-				 preg_match ('/^(a(nd?|s|t)?|b(ut|y)|en|for|i[fn]|o[fnr]|t(he|o)|vs?\.?|via)[ \-]/i', $m)
+				 preg_match ('/^(a(nd?|s|t)?|b(ut|y)|en|for|i[fn]|o[fnr]|t(he|o)|vs?\.?|via|\'(s|t|ll))[ \-]/i', $m)
 			?	//…and convert them to lowercase
 				mb_strtolower ($m, 'UTF-8')
 

--- a/title-capitalization-for-wordpress.php
+++ b/title-capitalization-for-wordpress.php
@@ -25,6 +25,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path:       /languages
  * Text Domain:       title-capitalization-for-wordpress
+ * Network:           false
  * GitHub Plugin URI: tommcfarlin/title-capitalization-for-wordpress
  * GitHub Branch:     master
  */

--- a/title-capitalization-for-wordpress.php
+++ b/title-capitalization-for-wordpress.php
@@ -18,7 +18,7 @@
  * Plugin Name:       Title Capitalization For WordPress
  * Plugin URI:        http://tommcfarlin.com/title-capitalization-for-wordpress/
  * Description:       Converts post and page titles and post content headings into proper capitalization.
- * Version:           1.1.3
+ * Version:           1.1.4
  * Author:            Tom McFarlin
  * Author URI:        http://tommcfarlin.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
This should fix https://github.com/tommcfarlin/title-capitalization-for-wordpress/issues/11